### PR TITLE
Small documentation update.

### DIFF
--- a/lib/Dancer/Plugin/SimpleCRUD.pm
+++ b/lib/Dancer/Plugin/SimpleCRUD.pm
@@ -1041,17 +1041,6 @@ L<http://search.cpan.org/dist/Dancer-Plugin-SimpleCRUD/>
 =back
 
 
-=head1 ACKNOWLEDGEMENTS
-
-Alberto Simões (ambs)
-
-Jonathan Barber
-
-saberworks
-
-jasonjayr
-
-
 =head1 LICENSE AND COPYRIGHT
 
 Copyright 2010-11 David Precious.


### PR DESCRIPTION
It took me a while to work out why my before_template_render hook wasn't being called, so I thought I'd document the reason.  I hope that what I have written is correct.

I also removed a duplicate acknowledgements section.

You'll need to run pod2readme again, I'm afraid.

Thanks very much for this module.
