### PR TITLE
fix call to Dancer::Plugin::Auth::Extensible

### DIFF
--- a/lib/Dancer/Plugin/SimpleCRUD.pm
+++ b/lib/Dancer/Plugin/SimpleCRUD.pm
@@ -1305,7 +1305,7 @@ sub _ensure_auth {
     } else {
         for my $keyword (qw(require_role require_any_role require_all_roles)) {
             if (my $val = $auth_settings->{$keyword}) {
-                return $handler = Dancer::Plugin::Auth::Extensible->$keyword(
+                return $handler = Dancer::Plugin::Auth::Extensible->can($keyword)->(
                     $val, $handler
                 );
             }


### PR DESCRIPTION
The OO style call via -> adds an additional param which makes Dancer::Plugin::Auth::Extensible::require_role (for example) fail. This makes sure no extra args are added.
