### PR TITLE
Security fix: Don't display unescaped search fields back to the browser.

### DIFF
--- a/lib/Dancer/Plugin/SimpleCRUD.pm
+++ b/lib/Dancer/Plugin/SimpleCRUD.pm
@@ -35,6 +35,7 @@ use Dancer qw(:syntax);
 use Dancer::Plugin::Database;
 use HTML::Table::FromDatabase;
 use CGI::FormBuilder;
+use HTML::Entities;
 
 our $VERSION = '0.92';
 
@@ -972,7 +973,7 @@ SEARCHFORM
             $html
                 .= sprintf(
                 "<p>Showing results from searching for '%s' in '%s'",
-                params->{'q'}, params->{searchfield});
+                encode_entities(params->{'q'}), encode_entities(params->{searchfield}));
             $html .= sprintf '&mdash;<a href="%s">Reset search</a></p>',
                 _external_url($args->{dancer_prefix}, $args->{prefix});
         }


### PR DESCRIPTION
There may be other instances of this bug, but I did not spot them (yet)
