### PR TITLE
Turn custom_columns into an arrayref of hashrefs.

### DIFF
--- a/lib/Dancer/Plugin/SimpleCRUD.pm
+++ b/lib/Dancer/Plugin/SimpleCRUD.pm
@@ -1243,10 +1243,10 @@ SEARCHFORM
     }
 
     my @custom_callbacks = ();
-    foreach my $column_alias ( keys %{ $args->{custom_columns} || {} } ) {
-        push @custom_callbacks, { 
-            column=>$column_alias, 
-            transform=> ($args->{custom_columns}->{$column_alias}->{transform} or sub { return shift;}),
+    for my $custom_col_spec (@{ $args->{custom_columns} || [] } ) {
+        push @custom_callbacks, {
+            column=>$custom_col_spec->{name}, 
+            transform=> ($custom_col_spec->{transform} or sub { return shift;}),
         };
     }
     my $table = HTML::Table::FromDatabase->new(

--- a/lib/Dancer/Plugin/SimpleCRUD.pm
+++ b/lib/Dancer/Plugin/SimpleCRUD.pm
@@ -1205,7 +1205,7 @@ SEARCHFORM
         # Get a list of all columns (normal, and custom_columns), then assemble
         # the names and labels to pass to HTML::Table::FromDatabase
         my @all_cols = map { $_->{COLUMN_NAME} } @$columns;
-        push @all_cols, keys %{ $args->{custom_columns} }
+        push @all_cols, map { $_->{name} } @{ $args->{custom_columns} }
             if exists $args->{custom_columns};
         %columns_sort_options = map {
             my $col_name       = $_;

--- a/lib/Dancer/Plugin/SimpleCRUD.pm
+++ b/lib/Dancer/Plugin/SimpleCRUD.pm
@@ -443,6 +443,30 @@ For a somewhat spurious example:
     ],
     ...
 
+
+The C<transform> code ref is passed to L<HTML::Table::FromDatabase> as a
+callback for that column, so it can do anything a
+L<HTML::Table::FromDatabase callback|HTML::Table::FromDatabase/callbacks>
+can do.  In particular, the coderef will receive the value of the
+column as the first parameter, but also a reference to the whole row hashref
+as the second parameter, so you can do a variety of cunning things.
+
+An example of a custom column whose C<transform> coderef uses the row
+hashref to get other values for the same row could be:
+
+    ...
+    custom_columns => [
+        {
+            name => 'salutation',
+            raw_column => 'name',
+            transform => sub {
+                my ($name_value, $row) = @_;
+                return "Hi, $row->{title} $name_value!";
+            },
+        }
+    ],
+    ...
+
 =item C<auth>
 
 You can require that users be authenticated to view/edit records using the C<auth>

--- a/lib/Dancer/Plugin/SimpleCRUD.pm
+++ b/lib/Dancer/Plugin/SimpleCRUD.pm
@@ -1213,7 +1213,7 @@ SEARCHFORM
             if ($args->{labels}{$col_name}) {
                 $friendly_name = $args->{labels}{$col_name};
             } else {
-                $friendly_name = prettify_column_name($friendly_name);
+                $friendly_name = _prettify_column_name($friendly_name);
             }
             if ($col_name eq $order_by_column) {
                 $direction = $opposite_order_by_direction;
@@ -1236,7 +1236,7 @@ SEARCHFORM
                 map { $_->{name} } @{ $args->{custom_columns} }
             ) {
                 $columns_sort_options{$custom_column_name}
-                    = prettify_column_name($custom_column_name);
+                    = _prettify_column_name($custom_column_name);
             }
         }
 
@@ -1611,7 +1611,7 @@ sub _get_where_filter_from_args {
     }
 }
 
-sub prettify_column_name {
+sub _prettify_column_name {
     my $name = shift;
     for ($name) {
         $_ = lc;

--- a/lib/Dancer/Plugin/SimpleCRUD.pm
+++ b/lib/Dancer/Plugin/SimpleCRUD.pm
@@ -448,7 +448,7 @@ For a somewhat spurious example:
 
 The C<transform> code ref is passed to L<HTML::Table::FromDatabase> as a
 callback for that column, so it can do anything a
-L<HTML::Table::FromDatabase callback|HTML::Table::FromDatabase/callbacks>
+L<HTML::Table::FromDatabase callback|HTML::Table::FromDatabase/CALLBACKS>
 can do.  In particular, the coderef will receive the value of the
 column as the first parameter, but also a reference to the whole row hashref
 as the second parameter, so you can do a variety of cunning things.

--- a/lib/Dancer/Plugin/SimpleCRUD.pm
+++ b/lib/Dancer/Plugin/SimpleCRUD.pm
@@ -1216,7 +1216,7 @@ SEARCHFORM
                 $friendly_name = $args->{labels}{$col_name};
             } else {
                 for ($friendly_name) {
-                    lc($friendly_name);
+                    $_ = lc;
                     s{_}{ }g;
                     s{\b(\w)}{\u$1}g;
                 }


### PR DESCRIPTION
This is for Issue #65 

Previously it was a hashref, so the order the columns would appear in was
pretty much random, which is a bit shit.

The old style is still supported for backwards compatibility, but should be
considered deprecated (a future release might start issuing a warning if it's
used, and eventually support for it may be dropped - although the
backwards-compatibility code isn't exactly huge, so there's no rush, I don't
want to cause unnecessary breakage for people).

Not yet fully tested, but PR for visibility.