### PR TITLE
update CGI::FormBuilder version dependency

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -17,7 +17,7 @@ WriteMakefile(
         'Dancer::Plugin::Database' => 1.00,
         'Dancer::Plugin::Database::Core' => 0.15,
         'HTML::Table::FromDatabase' => 1.10,
-        'CGI::FormBuilder' => 0,
+        'CGI::FormBuilder' => 3.10,
         'DBD::CSV'   => 0,
     },
     dist                => { COMPRESS => 'gzip -9f', SUFFIX => 'gz', },


### PR DESCRIPTION
Upgrading CGI::FormBuilder from 3.09 to 3.10 fixes the 'CGI::param' warning below when running #72 on perl 5.24.0

````
% make test
PERL_DL_NONLAZY=1 "/opt/perlbrew/perls/perl-5.24.0/bin/perl" "-MExtUtils::Command::MM" "-MTest::Harness" "-e" "undef *Test::Harness::Switches; test_harness(0, 'blib/lib', 'blib/arch')" t/*.t
t/00-load.t ........ 1/1 # Testing Dancer::Plugin::SimpleCRUD 0.99, Perl 5.024000, /opt/perlbrew/perls/perl-5.24.0/bin/perl
t/00-load.t ........ ok
t/01-basic-dpsc.t .. 2/? 

CGI::param called in list context from /opt/perlbrew/perls/perl-5.24.0/lib/site_perl/5.24.0/CGI/FormBuilder/Field.pm line 192, 
this can lead to vulnerabilities. See the warning in "Fetching the value or values of a single named parameter" 
at /opt/perlbrew/perls/perl-5.24.0/lib/site_perl/5.24.0/CGI.pm line 412.

t/01-basic-dpsc.t .. ok
t/manifest.t ....... skipped: Author tests not required for installation
t/pod-coverage.t ... ok
t/pod.t ............ ok
All tests successful.
Files=5, Tests=10,  3 wallclock secs ( 0.03 usr  0.01 sys +  0.67 cusr  0.06 csys =  0.77 CPU)
Result: PASS
````