### PR TITLE
Get the "/widgets/add" form to accept values from params()

### DIFF
--- a/lib/Dancer/Plugin/SimpleCRUD.pm
+++ b/lib/Dancer/Plugin/SimpleCRUD.pm
@@ -787,13 +787,15 @@ sub _create_add_edit_route {
         ),
     );
     for my $field (@editable_columns) {
-        # values_from_database contains what was in the database for this 
-        # object, if it already existed in the database.  $args->{default_value}
-        # is the default, if any, requested by the user for this field in the 
+        # first check if there's data from the database for this field,
+        # then if there's a value in params() for this field,
+        # then if args->{default_value} was set for this field via the
         # 'default_value' hash when the route was created.
         my $default = 
                 exists $values_from_database->{$field}  
               ? $values_from_database->{$field}
+              : exists params->{$field} 
+              ? uri_unescape(params->{$field})
               : exists $args->{default_value}->{$field} 
               ? $args->{default_value}->{$field}
               : '';


### PR DESCRIPTION
  for https://github.com/bigpresh/Dancer-Plugin-SimpleCRUD/issues/74

Adds needed feature of allowing /widgets/add form values to be set via links like
     /widgets/add?name=default_name_here

@bigpresh  @msouth 