### PR TITLE
SECURITY: Fix misused _ensure_auth calls

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -22,6 +22,7 @@ WriteMakefile(
         'DBD::SQLite'   => 1.50,
         'HTML::TreeBuilder' => 5.03,
         'List::MoreUtils' => 0.416,
+        'Dancer::Plugin::Auth::Extensible' => 0,    # for auth login tests 
     },
     dist                => { COMPRESS => 'gzip -9f', SUFFIX => 'gz', },
     clean               => { FILES => 'Dancer-Plugin-SimpleCRUD-*' },

--- a/lib/Dancer/Plugin/SimpleCRUD.pm
+++ b/lib/Dancer/Plugin/SimpleCRUD.pm
@@ -582,7 +582,6 @@ sub simple_crud {
         }
     }
     if ($args{addable}) {
-        _ensure_auth('edit', $handler, \%args);
         for ('/add') {
             my $url = _construct_url($args{prefix}, $_);
             Dancer::Logger::debug("Setting up route for $url");

--- a/lib/Dancer/Plugin/SimpleCRUD.pm
+++ b/lib/Dancer/Plugin/SimpleCRUD.pm
@@ -573,11 +573,12 @@ sub simple_crud {
         = sub { _create_add_edit_route(\%args, $table_name, $key_column); };
 
     if ($args{editable}) {
-        _ensure_auth('edit', $handler, \%args);
         for ('/edit/:id') {
             my $url = _construct_url($args{prefix}, $_);
             Dancer::Logger::debug("Setting up route for $url");
-            any ['get', 'post'] => $url => $handler;
+            any ['get', 'post'] => $url => _ensure_auth(
+                'edit', $handler, \%args,
+            );
         }
     }
     if ($args{addable}) {
@@ -585,7 +586,9 @@ sub simple_crud {
         for ('/add') {
             my $url = _construct_url($args{prefix}, $_);
             Dancer::Logger::debug("Setting up route for $url");
-            any ['get', 'post'] => $url => $handler;
+            any ['get', 'post'] => $url => _ensure_auth(
+                'edit', $handler, \%args
+            );
         }
     }
 
@@ -656,8 +659,9 @@ CONFIRMDELETE
 
             redirect _external_url($args{dancer_prefix}, $args{prefix});
         };
-        _ensure_auth('edit', $delete_handler, \%args);
-        post qr[$del_url_stub/?(.+)?$] => $delete_handler;
+        post qr[$del_url_stub/?(.+)?$] => _ensure_auth(
+            'edit', $delete_handler, \%args
+        );
     }
     my $view_url_stub = _construct_url(
         $args{prefix}, '/view'

--- a/t/01-basic-dpsc.t
+++ b/t/01-basic-dpsc.t
@@ -40,6 +40,11 @@ sub main {
 
     # test basic routes return 200 codes
     response_status_is [GET => '/users'], 200, "GET /users returns 200";
+    response_status_is [GET => '/users_auth'], 302, "GET /users_auth returns 302";
+
+    response_status_is [GET => '/users_auth/add'], 302, "GET /users_auth/add returns 302";
+    response_status_is [GET => '/users_auth/edit/1'], 302, "GET /users_auth/edit/1 returns 302";
+
     response_status_is [GET => '/users/add'], 404,
         "GET /users/add returns 404";
     response_status_is [GET => '/users_editable/add'], 200,

--- a/t/lib/TestApp.pm
+++ b/t/lib/TestApp.pm
@@ -34,7 +34,8 @@ my $id_custom_column    = { name => 'id', raw_column => 'id', transform => sub {
 my $username_custom_column = { name => "username", raw_column=>"username", transform => sub { "Username: $_[0]" }, column_class=>"classhere" };
 
 # now set up our simple_crud interfaci
-simple_crud( prefix => '/users'  ,              record_title=>'A', db_table => 'users', editable => 0, );
+simple_crud( prefix => '/users',                record_title=>'A', db_table => 'users', editable => 0, );
+simple_crud( prefix => '/users_auth',           record_title=>'A', db_table => 'users', editable => 1, auth => { require_login => 1 } );
 simple_crud( prefix => '/users_editable',       record_title=>'A', db_table => 'users', editable => 1, );
 simple_crud( prefix => '/users_editable_not_addable',       
                                                 record_title=>'A', db_table => 'users', editable => 1, addable => 0);


### PR DESCRIPTION
Oh, man.

Some places called `_ensure_auth()` in void context, presumably thinking it would modify the handler coderef given to inject authentication checking - but it doesn't, `_ensure_auth()` returns a new coderef which does the required authentication checks then calls the original handler coderef which was given to `_ensure_auth()`.  So, calling it in void context then passing the original handler coderef when setting up the route means there's no actual checking done on that route.  Oops.

This is a pretty embarassing fuckup - a security problem on one of my projects.  I hold my hands up and apologise to anyone affected by this, for this is a stupid mistake.  A better test suite would have caught this.

I will see if a CVE ID is warranted for this, and apply for one if so.

Big thanks to @joshrabinowitz for finding and reporting this one, and for adding tests which demonstrated the issue.